### PR TITLE
FIX extension broken after HTML change on PH

### DIFF
--- a/seenhunt.chromeextension/seenhunt.js
+++ b/seenhunt.chromeextension/seenhunt.js
@@ -35,7 +35,7 @@ var getSeen = function(id){
 };
 
 
-var elements = document.querySelectorAll('div.post--content');
+var elements = document.querySelectorAll('div.post-item--content');
 Array.prototype.forEach.call(elements, function(el, i){
     var id = el.getAttribute('data-href');
     var seen = getSeen(id);


### PR DESCRIPTION
A change occured in Product Hunt design where `.post--content` elements
were renamed `.post-item--content`.

This fixes the chrome extension. Fix on safari extension should be
pretty much the same, but I didn't do it because I can't run it.
